### PR TITLE
feat(bridge-step2): register syntax, @init form, Λ reduction to lambd…

### DIFF
--- a/BRIDGE_DESIGN.md
+++ b/BRIDGE_DESIGN.md
@@ -86,18 +86,37 @@ different operations. Resolution:
 Each step lands only with its tests; full suite green throughout;
 INVARIANTS.md checked at every step.
 
-## Open items (settle during step 2, before syntax freezes)
+## Resolved items (ratified for Step 2, 2026-08-03)
 
-These items must be resolved during Step 2 of the implementation plan.
-Until then, they are considered provisional and must not be
-implemented implicitly.
+Formerly the "open items." All three are now fixed contract:
 
-- Register naming syntax (proposal: `@name`; must not collide with
-  existing allowed-character set — parser change required either way).
-- How registers are initialized from DSL source (complex literal
-  syntax vs. loading two reals; leaning: load form `@z 1.0 2.0`
-  = 1+2i, avoiding a new literal class).
-- Whether Λ-reduction writes to a chosen real scalar or to a
-  dedicated observable slot (leaning: dedicated slot first —
-  writing into pinned scalars touches the corridor and needs its own
-  invariant review).
+1. **Register naming: `@name`.** Any token of the form `@name` is a
+   register identifier referring to `context.zfield["@name"]`. The
+   `@` prefix is reserved for complex registers only. The tokenizer
+   treats `@name` as a distinct operand kind ("register identifier"),
+   which is the basis for operand-kind dispatch. Register access never
+   touches pinned scalars.
+2. **Register initialization: `@z 1.0 2.0`** (bare command form; no
+   complex literal class). First token names the register, second is
+   the real part, third the imaginary part: sets
+   `zfield["@z"] = 1.0+2.0j`. **Exactly two numeric arguments** —
+   fewer or more is a hard error, never silently coerced.
+   Re-initialization overwrites cleanly. Unset registers still read
+   as 0j (Step-1 plumbing). A future `load` verb, if introduced, must
+   be a strict superset of this form.
+3. **Λ-reduction target: dedicated observable slot
+   `context.lambda_obs`** (real-valued, 0.0 default). `Λ @z @w`
+   applies the math-core Λ to the two registers and writes the real
+   result to `lambda_obs`. Λ NEVER writes to pinned scalars
+   (psi_signal / phi_state / epsilon_drift / stabilized_value);
+   mirroring `lambda_obs` into a scalar, if ever wanted, is a
+   separate explicit future operation. `lambda_obs` participates in
+   context persistence and forking like other context fields. The
+   math-core Λ is binary, so the register form takes exactly two
+   register operands.
+
+Dispatch consequences, restated as syntax rules: unary/literal Φ/Ψ/ε
+keep pinned DSL semantics; `Λ @z @w` is the first math-core register
+form; mixed forms (`Λ @z 1.0`, `Φ @z 1.0`, …) are rejected outright;
+binary register forms for Φ/Ψ/ε are NOT part of Step 2 and may only be
+added (Step 3) after Step-2 tests are green.

--- a/phi_pi_e_interpreter.py
+++ b/phi_pi_e_interpreter.py
@@ -93,8 +93,12 @@ class FieldContext:
         # Complex registers for the Φπε math core. STRICTLY isolated
         # from the real scalars: nothing in this dict may read or write
         # psi_signal / phi_state / epsilon_drift / stabilized_value.
-        # No DSL syntax touches this yet (syntax is Step 2).
+        # Populated by @name syntax (Step 2) and math-core register ops.
         self.zfield: Dict[str, complex] = zfield if zfield is not None else {}
+        # Dedicated Λ-reduction observable (BRIDGE_DESIGN resolved item 3).
+        # Real-valued; the ONLY landing site for ℂ→ℝ reduction. Never
+        # aliased to pinned scalars.
+        self.lambda_obs: float = 0.0
 
     def write_register(self, name: str, value: complex) -> None:
         """Write a complex value to a named shadow register.
@@ -125,7 +129,9 @@ class FieldContext:
             charge=self.charge
         )
         self.state.add_child(new_state.id)
-        return FieldContext(new_state, zfield=self.zfield)
+        child = FieldContext(new_state, zfield=self.zfield)
+        child.lambda_obs = self.lambda_obs  # carried like phase/charge
+        return child
 
     def merge(self, other: 'FieldContext') -> None:
         """Merge another context into this one"""
@@ -231,19 +237,29 @@ class PhiPiEInterpreterFixed:
         # Remove ASCII_OUTPUT_MODE marker
         code = code.replace('ASCII_OUTPUT_MODE', '').replace('[:ASCII:]', '')
 
-        # Proper allowed characters including all Greek letters, newline, and '-'
-        allowed_chars = set('ΦΠΕεΔδΨΛλΓΩωΣΞζΤΡΘηχn→+::/|[]=()0123456789.,- \n')
+        # Proper allowed characters including all Greek letters, newline, '-',
+        # and (Step 2) '@' + ascii letters/underscore for register identifiers.
+        allowed_chars = set('ΦΠΕεΔδΨΛλΓΩωΣΞζΤΡΘηχn→+::/|[]=()0123456789.,- \n@_'
+                            'abcdefghijklmnopqrstuvwxyz'
+                            'ABCDEFGHIJKLMNOPQRSTUVWXYZ')
         code = ''.join(c for c in code if c in allowed_chars)
 
         return code
 
     # Matches an int or float literal, optionally negative (e.g. 5, 5.0, -0.2)
     _NUMBER_RE = re.compile(r'-?(\d+\.\d*|\.\d+|\d+)')
+    # Matches a register identifier (BRIDGE_DESIGN Step 2): @name
+    _REGISTER_RE = re.compile(r'@[A-Za-z_][A-Za-z0-9_]*')
 
     @classmethod
     def is_number_token(cls, token: str) -> bool:
         """True if the token is a numeric literal produced by tokenize()."""
         return bool(cls._NUMBER_RE.fullmatch(token))
+
+    @classmethod
+    def is_register_token(cls, token: str) -> bool:
+        """True if the token is a register identifier (e.g. '@z')."""
+        return bool(cls._REGISTER_RE.fullmatch(token))
 
     def tokenize(self, code: str) -> List[str]:
         """Tokenize code into operators and NUMBER literals.
@@ -259,6 +275,16 @@ class PhiPiEInterpreterFixed:
             # Skip whitespace
             if char in ' \t\n\r':
                 i += 1
+                continue
+
+            # Register identifier (Step 2): @name
+            if char == '@':
+                m = self._REGISTER_RE.match(code, i)
+                if m:
+                    tokens.append(m.group(0))
+                    i = m.end()
+                    continue
+                i += 1  # bare '@' with no valid name: skip
                 continue
 
             # NUMBER literal (int/float, optional leading '-')
@@ -333,7 +359,50 @@ class PhiPiEInterpreterFixed:
                     # Handle loop
                     loop_code = token[1:-1]  # Remove brackets
                     current_value = self.execute_loop(loop_code, context)
+                elif self.is_register_token(token):
+                    # Register initialization: @name RE IM  (exactly two
+                    # numeric args — BRIDGE_DESIGN resolved item 2)
+                    following = tokens[i + 1:i + 4]
+                    nums = []
+                    for t in following:
+                        if self.is_number_token(t):
+                            nums.append(t)
+                        else:
+                            break
+                    if len(nums) != 2:
+                        raise SyntaxError(
+                            f"register initialization requires exactly two "
+                            f"numeric arguments: '{token} RE IM' "
+                            f"(got {len(nums)})")
+                    context.write_register(
+                        token, complex(float(nums[0]), float(nums[1])))
+                    i += 2
+                elif token == 'Λ' and i + 1 < len(tokens) \
+                        and self.is_register_token(tokens[i + 1]):
+                    # Λ register reduction: Λ @z @w -> lambda_obs
+                    # (BRIDGE_DESIGN resolved item 3; math-core Λ is binary)
+                    operands = tokens[i + 1:i + 3]
+                    if len(operands) != 2 or \
+                            not all(self.is_register_token(t) for t in operands):
+                        raise SyntaxError(
+                            "Λ register reduction requires exactly two "
+                            "register operands: 'Λ @z @w' — mixed or "
+                            "partial forms are forbidden")
+                    from phi_pi_e_math_core import structural_illumination
+                    z = context.read_register(operands[0])
+                    w = context.read_register(operands[1])
+                    context.lambda_obs = structural_illumination(z, w).real
+                    current_value = context.lambda_obs
+                    i += 2
                 elif token in self.symbols:
+                    # Guard: no other symbol accepts register operands yet
+                    # (binary Φ/Ψ/ε register forms are Step 3, and mixed
+                    # forms are forbidden outright per BRIDGE_DESIGN)
+                    if i + 1 < len(tokens) and self.is_register_token(tokens[i + 1]):
+                        raise SyntaxError(
+                            f"'{token}' does not accept register operands "
+                            f"in Step 2 (only Λ reduces registers; binary "
+                            f"register forms arrive in Step 3)")
                     handler = self.symbols[token]
                     # Φ with three numeric args is a full state initialization:
                     #   Φ ψ φ ε   (e.g. "Φ 5 3 0.1" -> psi=5, phi=3, eps=0.1)

--- a/tests/test_register_syntax.py
+++ b/tests/test_register_syntax.py
@@ -1,0 +1,150 @@
+# Tests for feat/bridge-step2-register-syntax — BRIDGE_DESIGN Step 2
+#
+# Register syntax (@name), initialization form (@z RE IM, exactly two
+# numeric args), and Λ register reduction into context.lambda_obs.
+# Pins the ratified resolved items 1-3 and the dispatch prohibitions
+# (mixed forms rejected; no non-Λ symbol accepts registers in Step 2).
+
+import contextlib
+import io
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from phi_pi_e_interpreter import FieldContext, PhiPiEInterpreterFixed
+from phi_pi_e_math_core import structural_illumination
+
+
+def run(program, ctx=None):
+    interp = PhiPiEInterpreterFixed()
+    with contextlib.redirect_stdout(io.StringIO()):
+        if ctx is None:
+            result = interp.execute(program)
+        else:
+            result = interp.execute(program, ctx)
+    return interp, result
+
+
+def run_raises(program):
+    interp = PhiPiEInterpreterFixed()
+    with contextlib.redirect_stdout(io.StringIO()):
+        with pytest.raises(RuntimeError):
+            interp.execute(program)
+
+
+class TestRegisterTokenization:
+    def test_register_is_single_token(self):
+        interp = PhiPiEInterpreterFixed()
+        assert interp.tokenize(interp.clean_input("@z 1.0 2.0")) == \
+            ['@z', '1.0', '2.0']
+
+    def test_register_names_with_underscores_and_digits(self):
+        interp = PhiPiEInterpreterFixed()
+        tokens = interp.tokenize(interp.clean_input("@epsilon_reg2 0.5 -0.5"))
+        assert tokens == ['@epsilon_reg2', '0.5', '-0.5']
+
+    def test_register_distinct_operand_kind(self):
+        interp = PhiPiEInterpreterFixed()
+        assert interp.is_register_token('@z')
+        assert not interp.is_register_token('5.0')
+        assert not interp.is_number_token('@z')
+        assert not interp.is_register_token('Φ')
+
+
+class TestRegisterInitialization:
+    def test_init_creates_complex_value(self):
+        interp, _ = run("@z 1.0 2.0")
+        assert interp.last_context.read_register('@z') == 1 + 2j
+
+    def test_reinit_overwrites_cleanly(self):
+        interp, _ = run("@z 1.0 2.0\n@z 3.0 4.0")
+        assert interp.last_context.read_register('@z') == 3 + 4j
+
+    def test_negative_components(self):
+        interp, _ = run("@w -1.5 -0.25")
+        assert interp.last_context.read_register('@w') == complex(-1.5, -0.25)
+
+    def test_unset_registers_still_read_zero(self):
+        interp, _ = run("@z 1.0 2.0")
+        assert interp.last_context.read_register('@never_set') == 0j
+
+    def test_zero_args_rejected(self):
+        run_raises("@z")
+
+    def test_one_arg_rejected(self):
+        run_raises("@z 1.0")
+
+    def test_three_args_rejected(self):
+        run_raises("@z 1.0 2.0 3.0")
+
+    def test_non_numeric_args_rejected(self):
+        run_raises("@z a b")  # letters are not numeric operands
+
+
+class TestLambdaReduction:
+    def test_lambda_reduces_to_lambda_obs(self):
+        interp, result = run("@z 2.0 3.0\n@w 1.0 -2.0\nΛ @z @w")
+        expected = structural_illumination(2 + 3j, 1 - 2j).real
+        assert abs(interp.last_context.lambda_obs - expected) < 1e-12
+        assert result == interp.last_context.lambda_obs
+
+    def test_lambda_obs_defaults_to_zero(self):
+        ctx = FieldContext()
+        assert ctx.lambda_obs == 0.0
+
+    def test_lambda_never_touches_pinned_scalars(self):
+        interp, _ = run("Φ 5.0\nΨ 3.0\nε 0.2\n@z 2.0 3.0\n@w 1.0 -2.0\nΛ @z @w\nΣ")
+        s = interp.last_context.state
+        # pinned scalars exactly as the canonical fixture demands:
+        assert (s.phi_state, s.psi_signal, s.epsilon_drift) == (5.0, 3.0, 0.2)
+        assert abs(s.stabilized_value - 6.4) < 1e-9
+        assert interp.last_context.lambda_obs != 0.0
+
+    def test_mixed_form_rejected(self):
+        run_raises("@z 2.0 3.0\nΛ @z 1.0")
+
+    def test_single_register_rejected(self):
+        run_raises("@z 2.0 3.0\nΛ @z")
+
+    def test_legacy_unary_lambda_unchanged(self):
+        """'Λ -1' (no registers) keeps modulator pass-through semantics
+        pinned by the category tests."""
+        interp, result = run("Λ -1")
+        assert result == -1.0
+        assert interp.last_context.lambda_obs == 0.0
+
+    def test_lambda_obs_carried_by_fork(self):
+        ctx = FieldContext()
+        ctx.lambda_obs = 3.25
+        child = ctx.fork()
+        assert child.lambda_obs == 3.25
+
+
+class TestStepTwoProhibitions:
+    def test_setters_reject_register_operands(self):
+        run_raises("@z 1.0 2.0\nΦ @z")
+
+    def test_binary_setter_register_form_not_yet_available(self):
+        run_raises("@z 1.0 2.0\n@w 3.0 4.0\nΦ @z @w")  # Step 3, not now
+
+    def test_reducer_sigma_rejects_registers(self):
+        run_raises("@z 1.0 2.0\nΣ @z")
+
+
+class TestPersistenceThroughSyntax:
+    def test_registers_survive_across_executes(self):
+        interp = PhiPiEInterpreterFixed()
+        ctx = FieldContext()
+        run("@z 1.0 2.0", ctx)
+        with contextlib.redirect_stdout(io.StringIO()):
+            interp.execute("Ψ 1", ctx)
+        assert ctx.read_register('@z') == 1 + 2j
+
+    def test_canonical_fixture_untouched_by_register_syntax_presence(self):
+        interp, result = run("Φ 5.0\nΨ 3.0\nε 0.2\nΣ")
+        assert abs(result - 6.4) < 1e-9
+        assert interp.last_context.zfield == {}
+        assert interp.last_context.lambda_obs == 0.0


### PR DESCRIPTION
…a_obs

Per BRIDGE_DESIGN resolved items (doc updated in same commit):
- tokenizer: @name register identifiers as distinct operand kind
- @z RE IM initialization — exactly two numeric args, hard error otherwise; reinit overwrites; unset registers still read 0j
- Λ @z @w dispatches math-core structural_illumination, writes real result to new context.lambda_obs (dedicated observable; never touches pinned scalars); lambda_obs carried by fork
- legacy unary Λ semantics unchanged (category tests still pin it)
- prohibitions enforced: mixed forms rejected; no non-Λ symbol accepts registers (binary Φ/Ψ/ε forms deferred to Step 3)
- 23 tests; full suite 242/242